### PR TITLE
feat(ci): add rpm assets to release

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -63,5 +63,6 @@ jobs:
         with:
           files: |
             src-tauri/target/release/bundle/deb/*_${{ env.APP_VERSION }}_amd64.deb
+            src-tauri/target/release/bundle/rpm/*-${{ env.APP_VERSION }}-1.x86_64.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In CI build we already have `rpm` files. I believe that we can safely add it to `Upload Release Assets` task

```bash
[appimage/stderr] at https://github.com/AppImage/appimage.github.io
    Finished [tauri_bundler::bundle] 3 bundles at:
        /home/runner/work/claw/claw/src-tauri/target/release/bundle/deb/claw_1.0.5_amd64.deb
        /home/runner/work/claw/claw/src-tauri/target/release/bundle/rpm/claw-1.0.5-1.x86_64.rpm
        /home/runner/work/claw/claw/src-tauri/target/release/bundle/appimage/claw_1.0.5_amd64.AppImage
```

Content of `rpm` file the same as `deb`

```bash
# rpm -ql claw
/usr/bin/claw
/usr/lib/claw
/usr/lib/claw/_up_/LICENSE
/usr/lib/claw/_up_/examples/claw.rune
/usr/lib/claw/_up_/examples/themes/catpuccin.rune
/usr/lib/claw/_up_/examples/themes/default.rune
/usr/lib/claw/_up_/examples/themes/dracula.rune
/usr/lib/claw/_up_/examples/themes/gruvbox.rune
/usr/lib/claw/_up_/examples/themes/nord.rune
/usr/lib/claw/_up_/examples/themes/solarized.rune
/usr/share/applications/claw.desktop
/usr/share/icons/hicolor/128x128/apps/claw.png
/usr/share/icons/hicolor/256x256@2/apps/claw.png
/usr/share/icons/hicolor/32x32/apps/claw.png
```